### PR TITLE
Fix stack smasing

### DIFF
--- a/src/libraw_wrapper.cpp
+++ b/src/libraw_wrapper.cpp
@@ -53,6 +53,8 @@ Napi::Value LibRawWrapper::GetThumbnail(const Napi::CallbackInfo& info) {
     env,
     "Thumbnail is not unpacked or is null."
   ).ThrowAsJavaScriptException();
+
+  return env.Undefined();
 }
 
 Napi::Value LibRawWrapper::GetXmpData(const Napi::CallbackInfo& info) {


### PR DESCRIPTION
Functions promising a `Napi::Value` must return _something_.

Since this function wants to throw a JS exception and terminate, we will update it to return `undefined` value to JS.