### PR TITLE
Cross-platform gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -10,12 +10,17 @@
       "include_dirs": [
         "<!@(node -p \"require('node-addon-api').include\")"
       ],
-      "libraries": ["/usr/local/lib/libraw_r.dylib"],
+      "cflags!": ["-fno-exceptions"],
+      "cflags_cc!": ["-fno-exceptions"],
       "conditions": [
         ['OS=="mac"', {
+          "libraries": ["/usr/local/lib/libraw_r.dylib"],
           'xcode_settings': {
             'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
           }
+        }],
+        ['OS=="linux', {
+          "libraries": ["/usr/local/lib/libraw_r.so"],
         }]
       ]
     }


### PR DESCRIPTION
Linux and macOS have different naming conventions for linker files.

This should specify the appropriate path for default LibRaw installations.