### PR TITLE
Fix gyp typo

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -19,7 +19,7 @@
             'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
           }
         }],
-        ['OS=="linux', {
+        ['OS=="linux"', {
           "libraries": ["/usr/local/lib/libraw_r.so"],
         }]
       ]


### PR DESCRIPTION
I'm working on configuring CI and failed to notice a typo in my `gyp` binding. Ironically, CI would've caught the error.