### PR TITLE
Setup release fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "binary": {
     "module_name": "node_libraw_binding",
     "module_path": "./build/Release",
-    "host": "https://github.com/justinkambic/libraw.js/releases/download",
+    "host": "https://github.com/justinkambic/libraw.js/releases/download/",
     "remote_path": "{version}"
   },
   "husky": {
@@ -46,5 +46,9 @@
       "pre-commit": "npm run lint && npm run format-check",
       "pre-push": "npm test"
     }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/justinkambic/libraw.js.git"
   }
 }


### PR DESCRIPTION
I previously had done some baseline configuration for `node-pre-gyp` and `node-pre-gyp-github` to work. I plan to host releases on GitHub, as the package size is quite small. This fixes an issue with the `binary.host` field, and adds the `repository.type` and `repository.url` fields required for GitHub distribution.