### PR TITLE
Add caching step for LibRaw download to CI action

### DIFF
--- a/.github/workflows/build-package-and-test.yml
+++ b/.github/workflows/build-package-and-test.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           path: /home/runner/work/libraw.js/libraw.js/LibRaw-0.19.5.tar.gz
           key: ${{ runner.os }}-LibRaw-0.19.5.tar.gz
+          restore-keys: ${{ runner.os }}-LibRaw-0.19.5.tar.gz
       - id: list-files
         name: Run ls
         run: ls


### PR DESCRIPTION
We should cache LibRaw to prevent unnecessary repeated downloads of the same release version of the library.