### PR TITLE
Add Action to cache node_modules for CI

### DIFF
--- a/.github/workflows/build-package-and-test.yml
+++ b/.github/workflows/build-package-and-test.yml
@@ -43,6 +43,7 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+
       - id: install-npm
         name: Install npm Packages
         run: npm install


### PR DESCRIPTION
Attempting to configure CI to not download all node dependencies if `package-lock.json` has not changed.