### PR TITLE
Update flawed install script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "libraw",
+  "name": "libraw.js",
   "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -1690,9 +1690,10 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.14.tgz",
-      "integrity": "sha512-UHnOPWVWV1z+VV8k6L1HhG7UbGBgIdghqF3l9Ny9ApPghbjICXkUJSd/b9gOgQfjM1r+37cipdw/HJ3F6ICEnQ=="
+      "version": "14.14.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
+      "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -7005,9 +7006,10 @@
       }
     },
     "typescript": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
-      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ=="
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.12.8",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "format-check": "prettier --check .",
     "generate-docs": "typedoc --plugin typedoc-plugin-markdown --hideBreadcrumbs true --tsconfig ./tsconfig.json ./src/libraw.ts && rm ./docs/README.md",
     "lint": "eslint . --ext .ts",
-    "install": "node-pre-gyp install --fallback-to-build && tsc",
+    "install": "node-pre-gyp install --fallback-to-build",
     "test": "jest",
     "test-watch": "jest --watch"
   },

--- a/package.json
+++ b/package.json
@@ -8,17 +8,16 @@
   "license": "LGPL-2.1",
   "gypfile": true,
   "dependencies": {
-    "@types/node": "^14.14.7",
     "node-addon-api": "^3.0.0",
     "node-pre-gyp": "^0.16.0",
-    "node-pre-gyp-github": "^1.4.3",
-    "typescript": "^4.1.2"
+    "node-pre-gyp-github": "^1.4.3"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",
     "@babel/preset-env": "^7.12.7",
     "@babel/preset-typescript": "^7.12.7",
     "@types/jest": "^26.0.15",
+    "@types/node": "^14.14.41",
     "@typescript-eslint/eslint-plugin": "^4.8.2",
     "@typescript-eslint/parser": "^4.8.2",
     "babel-jest": "^26.6.3",
@@ -29,7 +28,8 @@
     "jest": "^26.6.3",
     "prettier": "^2.2.0",
     "typedoc": "^0.20.25",
-    "typedoc-plugin-markdown": "^3.5.0"
+    "typedoc-plugin-markdown": "^3.5.0",
+    "typescript": "^4.2.4"
   },
   "engines": {
     "node": ">=10.24.0 <=15.11.0"


### PR DESCRIPTION
The install script calls `tsc` and this is not necessary for installs as the package is already built on install. I haven't used this script in a long time and didn't notice the issue.

Also moved typescript and @types/node to dev dependencies.