### PR TITLE
Add `NODE_MODULE` v93 to compatibility matrix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ are assigned likewise. For instance, increasing support from LibRaw version 0.19
 
 ### Compatibility matrix
 
-| `libraw.js` version | LibRaw version | `NODE_MODULE` version  |
-| :------------------ | :------------- | :--------------------- |
-| 1.0.0               | 0.19.5         | 64, 67, 72, 79, 83, 88 |
-| 2.0.0               | 0.20.0         | 64, 67, 72, 79, 83, 88 |
-| 2.1.0               | 0.20.1         | 64, 67, 72, 79, 83, 88 |
-| 2.2.0               | 0.20.2         | 64, 67, 72, 79, 83, 88 |
+| `libraw.js` version | LibRaw version | `NODE_MODULE` version      |
+| :------------------ | :------------- | :------------------------- |
+| 1.0.0               | 0.19.5         | 64, 67, 72, 79, 83, 88, 93 |
+| 2.0.0               | 0.20.0         | 64, 67, 72, 79, 83, 88, 93 |
+| 2.1.0               | 0.20.1         | 64, 67, 72, 79, 83, 88, 93 |
+| 2.2.0               | 0.20.2         | 64, 67, 72, 79, 83, 88, 93 |
 
 #### Node release version matrix
 


### PR DESCRIPTION
At the moment `libraw.js` supports up to `NODE_MODULE` 93 with node 16.0.0. This adds that to the compatibility matrix.