### PR TITLE
Fix LibRawWrapper function param name in type definition

### DIFF
--- a/src/libraw.ts
+++ b/src/libraw.ts
@@ -36,7 +36,7 @@ interface LibRawWrapper {
   getXmp: () => Buffer;
   cameraCount: () => number;
   cameraList: () => string[];
-  open_file: (filename: string, bifile_size?: number) => number;
+  open_file: (filename: string, bigfile_size?: number) => number;
   open_buffer: (buffer: Buffer) => number;
   recycle: () => void;
   recycle_datastream: () => void;


### PR DESCRIPTION
The type definitions exported by LibRaw.js that interact with the node addon API have a typo for one of the variable names.