### PR TITLE
Modify prebuild workflow

### DIFF
--- a/.github/workflows/build-package-and-test.yml
+++ b/.github/workflows/build-package-and-test.yml
@@ -11,24 +11,28 @@ jobs:
     runs-on: ubuntu-latest
     name: build
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         id: checkout-code
         name: Checkout
+      - uses: actions/setup-node@v4
+        name: Setup Node
+        with:
+          node-version: '18'
       - id: dependencies
         name: Build Dependencies
-        run: sudo apt-get update && sudo apt-get install -y nodejs node-gyp libssl1.1
+        run: sudo apt-get update && sudo apt-get install -y build-essential python3 pkg-config
       - id: get-libjpeg
         name: Get libjpeg
-        run: curl -XGET http://www.ijg.org/files/jpegsrc.v9d.tar.gz -o jpegsrc.v9d.tar.gz
+        run: curl -fsSL http://www.ijg.org/files/jpegsrc.v9d.tar.gz -o jpegsrc.v9d.tar.gz
       - id: install-libjpeg
         name: Install libjpeg
-        run: tar xofp jpegsrc.v9d.tar.gz && cd jpeg-9d && ./configure --with-pic && make && sudo make install
+        run: tar xzf jpegsrc.v9d.tar.gz && cd jpeg-9d && ./configure --with-pic && make -j"$(nproc)" && sudo make install
       - id: get-libraw
         name: Download LibRaw Release
-        run: curl https://www.libraw.org/data/LibRaw-0.21.2.tar.gz --output LibRaw-0.21.2.tar.gz
+        run: curl -fsSL https://www.libraw.org/data/LibRaw-0.21.2.tar.gz -o LibRaw-0.21.2.tar.gz
       - id: install-libraw
         name: Install LibRaw
-        run: tar xzvf LibRaw-0.21.2.tar.gz && cd LibRaw-0.21.2 && ./configure --with-pic --disable-openmp && touch * && make && sudo make install
+        run: tar xzf LibRaw-0.21.2.tar.gz && cd LibRaw-0.21.2 && ./configure --with-pic --disable-openmp && make -j"$(nproc)" && sudo make install
       - id: pkg-config-check
         name: Check pkg-config
         run: |
@@ -40,18 +44,15 @@ jobs:
       - id: clean-libraw-files
         name: Clean LibRaw Build Files
         run: rm -rf LibRaw-0.21.2 LibRaw-0.21.2.tar.gz
-      - id: global-npm
-        name: Setup Global npm Packages
-        run: sudo npm i -g node-gyp node-gyp-build
       - id: install-npm
         name: Install npm Packages
-        run: npm install
+        run: npm ci
       - id: lint
         name: Lint
         run: npm run format-check && npm run lint
       - id: build-package
         name: Build Package
-        run: node-gyp rebuild
+        run: npm run build
       - id: unit-tests
         name: Run Unit Tests
         run: npm run test

--- a/.github/workflows/build-package-and-test.yml
+++ b/.github/workflows/build-package-and-test.yml
@@ -29,9 +29,11 @@ jobs:
       - id: install-libraw
         name: Install LibRaw
         run: tar xzvf LibRaw-0.21.1.tar.gz && cd LibRaw-0.21.1 && ./configure --with-pic --disable-openmp && touch * && make && sudo make install
-      - id: set-ld-library
-        name: LD Library
-        run: sudo ldconfig -v && LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+      - id: pkg-config-check
+        name: Check pkg-config
+        run: |
+          echo "pkg-config libraw --libs: $(pkg-config --libs libraw 2>/dev/null || echo 'not found')"
+          echo "pkg-config libjpeg --libs: $(pkg-config --libs libjpeg 2>/dev/null || echo 'not found')"
       - id: clean-libjpeg-files
         name: Clean libjpeg files
         run: rm -rf jpeg-9d jpegsrc.v9d.tar.gz

--- a/.github/workflows/build-package-and-test.yml
+++ b/.github/workflows/build-package-and-test.yml
@@ -25,10 +25,10 @@ jobs:
         run: tar xofp jpegsrc.v9d.tar.gz && cd jpeg-9d && ./configure --with-pic && make && sudo make install
       - id: get-libraw
         name: Download LibRaw Release
-        run: curl https://www.libraw.org/data/LibRaw-0.21.1.tar.gz --output LibRaw-0.21.1.tar.gz
+        run: curl https://www.libraw.org/data/LibRaw-0.21.2.tar.gz --output LibRaw-0.21.2.tar.gz
       - id: install-libraw
         name: Install LibRaw
-        run: tar xzvf LibRaw-0.21.1.tar.gz && cd LibRaw-0.21.1 && ./configure --with-pic --disable-openmp && touch * && make && sudo make install
+        run: tar xzvf LibRaw-0.21.2.tar.gz && cd LibRaw-0.21.2 && ./configure --with-pic --disable-openmp && touch * && make && sudo make install
       - id: pkg-config-check
         name: Check pkg-config
         run: |
@@ -39,7 +39,7 @@ jobs:
         run: rm -rf jpeg-9d jpegsrc.v9d.tar.gz
       - id: clean-libraw-files
         name: Clean LibRaw Build Files
-        run: rm -rf LibRaw-0.21.1 LibRaw-0.21.1.tar.gz
+        run: rm -rf LibRaw-0.21.2 LibRaw-0.21.2.tar.gz
       - id: global-npm
         name: Setup Global npm Packages
         run: sudo npm i -g node-gyp node-gyp-build

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -11,7 +11,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -72,7 +71,6 @@ jobs:
       - name: Install Homebrew deps
         run: |
           brew update
-          # Install bottles for jpeg and libraw to avoid building from source on macOS runners
           brew install jpeg libraw pkg-config python3
 
       - name: Export Homebrew environment
@@ -102,6 +100,8 @@ jobs:
     name: Create draft release with prebuilds
     runs-on: ubuntu-latest
     needs: [build-linux, build-macos]
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -109,7 +109,13 @@ jobs:
       - name: Read package version
         id: version
         run: |
-          node -e "const fs=require('fs');const pkg=require('./package.json');const out=process.env.GITHUB_OUTPUT; if(!out){console.error('GITHUB_OUTPUT not set'); process.exit(1);} fs.appendFileSync(out, 'VERSION='+pkg.version + '\n');"
+          node -e "
+            const fs = require('fs');
+            const pkg = require('./package.json');
+            const out = process.env.GITHUB_OUTPUT;
+            if (!out) { console.error('GITHUB_OUTPUT not set'); process.exit(1); }
+            fs.appendFileSync(out, 'VERSION=' + pkg.version + '\n');
+          "
 
       - name: Download Linux prebuilds artifact
         uses: actions/download-artifact@v4
@@ -125,57 +131,53 @@ jobs:
 
       - name: Prepare release assets
         run: |
+          set -euo pipefail
           mkdir -p release-assets
-          VERSION=${{ steps.version.outputs.VERSION }}
-          if [ -d artifacts/linux ]; then
-            cd artifacts/linux || exit 0
-            zip -r ../../release-assets/prebuilds-linux-v${VERSION}.zip . || true
-            cd ../..
-          fi
-          if [ -d artifacts/macos ]; then
-            cd artifacts/macos || exit 0
-            zip -r ../../release-assets/prebuilds-macos-v${VERSION}.zip . || true
-            cd ../..
-          fi
 
-      - name: Verify release assets exist
-        run: |
-          echo "Contents of release-assets:" 
-          ls -la release-assets
+          # Copy raw .node files with platform-arch prefix for easy identification
+          # prebuildify produces: prebuilds/<platform>-<arch>/node.napi.node
+          # but node-gyp-build expects: prebuilds/<platform>-<arch>/<package-name>.node
+          # The upload-artifact preserves the directory structure, so we flatten
+          # the .node files into release-assets with descriptive names.
 
-      - name: Create draft release
-        id: create_release
-        uses: actions/create-release@v1
-        with:
-          tag_name: v${{ steps.version.outputs.VERSION }}
-          release_name: "prebuild-v${{ steps.version.outputs.VERSION }}"
-          body: |
-            Automated prebuilds for version ${{ steps.version.outputs.VERSION }}.
-            - Commit: ${{ github.sha }}
-            - Workflow: ${{ github.workflow }}
-          draft: true
-          prerelease: false
+          for dir in artifacts/linux artifacts/macos; do
+            if [ -d "$dir" ]; then
+              find "$dir" -name "*.node" | while read -r node_file; do
+                # Extract the platform-arch directory name (e.g., linux-x64, darwin-arm64)
+                platform_arch=$(basename "$(dirname "$node_file")")
+                fname=$(basename "$node_file")
+                asset_name="${platform_arch}-${fname}"
+                echo "Copying ${node_file} -> release-assets/${asset_name}"
+                cp "$node_file" "release-assets/${asset_name}"
+              done
+            fi
+          done
+
+          echo "Release assets:"
+          ls -la release-assets/
+
+      - name: Create draft release and upload assets
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload prebuild assets to draft release
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          UPLOAD_URL="${{ steps.create_release.outputs.upload_url }}"
-          if [ -z "$UPLOAD_URL" ]; then
-            echo "ERROR: No upload_url from create_release step"
-            exit 1
-          fi
-          CLEAN_URL="${UPLOAD_URL%\{*}"
+          VERSION=${{ steps.version.outputs.VERSION }}
+          TAG="v${VERSION}"
+
+          # Create the draft release
+          gh release create "$TAG" \
+            --draft \
+            --title "v${VERSION}" \
+            --notes "Automated prebuilds for version ${VERSION}.
+          - Commit: ${{ github.sha }}
+          - Workflow: ${{ github.workflow }}"
+
+          # Upload all .node files as release assets
           for f in release-assets/*; do
             [ -f "$f" ] || continue
-            fname=$(basename "$f")
-            echo "Uploading $fname"
-            curl -sS -X POST \
-              -H "Authorization: token ${GITHUB_TOKEN}" \
-              -F "file=@${f};type=application/zip" \
-              "${CLEAN_URL}?name=$fname"
+            echo "Uploading $(basename "$f")"
+            gh release upload "$TAG" "$f"
           done
+
+          echo "Draft release ${TAG} created with assets:"
+          gh release view "$TAG"

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -186,12 +186,17 @@ jobs:
             [ -f "$f" ] || continue
             fname=$(basename "$f")
             echo "---> Uploading $fname to $UPLOAD_URL"
-            # Use verbose curl and capture HTTP status and response body
+            # The upload_url returned by GitHub is a template like
+            # https://uploads.github.com/repos/.../assets{?name,label}
+            # Strip the template suffix before using it.
+            CLEAN_URL="${UPLOAD_URL%\{*}"
+            echo "Using upload endpoint: $CLEAN_URL?name=$fname"
             resp_file="/tmp/upload_resp_${fname}"
+            # Use multipart/form-data as required by GitHub Releases API
             http_status=$(curl -sS -o "$resp_file" -w "%{http_code}" -X POST \
               -H "Authorization: token ${GITHUB_TOKEN}" \
-              -H "Content-Type: application/zip" \
-              --data-binary @"$f" "${UPLOAD_URL}?name=$fname") || true
+              -F "file=@${f};type=application/zip" \
+              "${CLEAN_URL}?name=$fname") || true
             echo "HTTP status: $http_status"
             echo "Response body for $fname:" && cat "$resp_file" || true
             echo "curl exit code: $?"

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -96,10 +96,52 @@ jobs:
           name: prebuilds-macos
           path: prebuilds
 
+  build-windows:
+    name: Build Windows prebuilds
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install dependencies via vcpkg
+        run: |
+          vcpkg install libraw:x64-windows-static-md libjpeg-turbo:x64-windows-static-md
+
+      - name: Export vcpkg prefix
+        run: |
+          $prefix = "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows-static-md"
+          echo "LIBRAW_PREFIX=$prefix" >> $env:GITHUB_ENV
+          echo "Installed headers:"
+          dir "$prefix\include\libraw" 2>$null
+          echo "Installed libs:"
+          dir "$prefix\lib\*.lib" 2>$null
+
+      - name: Install npm deps
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+        env:
+          LIBRAW_PREFIX: ${{ env.LIBRAW_PREFIX }}
+
+      - name: Run prebuildify
+        run: npx prebuildify --napi
+
+      - name: Upload Windows prebuilds
+        uses: actions/upload-artifact@v4
+        with:
+          name: prebuilds-windows
+          path: prebuilds
+
   publish-release:
     name: Create draft release with prebuilds
     runs-on: ubuntu-latest
-    needs: [build-linux, build-macos]
+    needs: [build-linux, build-macos, build-windows]
     permissions:
       contents: write
     steps:
@@ -129,6 +171,12 @@ jobs:
           name: prebuilds-macos
           path: artifacts/macos
 
+      - name: Download Windows prebuilds artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: prebuilds-windows
+          path: artifacts/windows
+
       - name: Prepare release assets
         run: |
           set -euo pipefail
@@ -140,7 +188,7 @@ jobs:
           # The upload-artifact preserves the directory structure, so we flatten
           # the .node files into release-assets with descriptive names.
 
-          for dir in artifacts/linux artifacts/macos; do
+          for dir in artifacts/linux artifacts/macos artifacts/windows; do
             if [ -d "$dir" ]; then
               find "$dir" -name "*.node" | while read -r node_file; do
                 # Extract the platform-arch directory name (e.g., linux-x64, darwin-arm64)

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -11,6 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -105,6 +106,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Read package version
+        id: version
+        run: |
+          echo "VERSION=$(node -p \"require('./package.json').version\")" >> $GITHUB_OUTPUT
+
       - name: Download Linux prebuilds artifact
         uses: actions/download-artifact@v4
         with:
@@ -120,14 +126,15 @@ jobs:
       - name: Prepare release assets
         run: |
           mkdir -p release-assets
+          VERSION=${{ steps.version.outputs.VERSION }}
           if [ -d artifacts/linux ]; then
             cd artifacts/linux || exit 0
-            zip -r ../../release-assets/prebuilds-linux-${{ github.run_id }}.zip . || true
+            zip -r ../../release-assets/prebuilds-linux-v${VERSION}.zip . || true
             cd ../..
           fi
           if [ -d artifacts/macos ]; then
             cd artifacts/macos || exit 0
-            zip -r ../../release-assets/prebuilds-macos-${{ github.run_id }}.zip . || true
+            zip -r ../../release-assets/prebuilds-macos-v${VERSION}.zip . || true
             cd ../..
           fi
 
@@ -135,10 +142,10 @@ jobs:
         id: create_release
         uses: actions/create-release@v1
         with:
-          tag_name: prebuild-${{ github.run_id }}
-          release_name: "prebuild-${{ github.run_id }}"
+          tag_name: v${{ steps.version.outputs.VERSION }}
+          release_name: "prebuild-v${{ steps.version.outputs.VERSION }}"
           body: |
-            Automated prebuilds for run ${{ github.run_id }}.
+            Automated prebuilds for version ${{ steps.version.outputs.VERSION }}.
             - Commit: ${{ github.sha }}
             - Workflow: ${{ github.workflow }}
           draft: true

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -164,23 +164,41 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload prebuild assets to draft release
+      - name: Upload prebuild assets to draft release (verbose)
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          echo "create_release outputs:"
+          echo "  upload_url: '${{ steps.create_release.outputs.upload_url }}'"
+          echo "  api url: '${{ steps.create_release.outputs.url }}'"
           UPLOAD_URL="${{ steps.create_release.outputs.upload_url }}"
           if [ -z "$UPLOAD_URL" ]; then
-            echo "No upload_url from create_release step"
+            echo "ERROR: No upload_url from create_release step"
             exit 1
           fi
+          # show files we will upload
+          echo "Files in release-assets:"
+          ls -la release-assets || true
+
           for f in release-assets/*; do
             [ -f "$f" ] || continue
             fname=$(basename "$f")
-            echo "Uploading $fname to $UPLOAD_URL"
-            curl -sS -X POST \
+            echo "---> Uploading $fname to $UPLOAD_URL"
+            # Use verbose curl and capture HTTP status and response body
+            resp_file="/tmp/upload_resp_${fname}"
+            http_status=$(curl -sS -o "$resp_file" -w "%{http_code}" -X POST \
               -H "Authorization: token ${GITHUB_TOKEN}" \
               -H "Content-Type: application/zip" \
-              --data-binary @"$f" "${UPLOAD_URL}?name=$fname"
+              --data-binary @"$f" "${UPLOAD_URL}?name=$fname") || true
+            echo "HTTP status: $http_status"
+            echo "Response body for $fname:" && cat "$resp_file" || true
+            echo "curl exit code: $?"
           done
+
+          # After uploads, query the release to list attached assets
+          REPO_API="https://api.github.com/repos/${{ github.repository }}"
+          RELEASE_API="$REPO_API/releases/tags/v${{ steps.version.outputs.VERSION }}"
+          echo "Querying release API: $RELEASE_API"
+          curl -sS -H "Authorization: token ${GITHUB_TOKEN}" "$RELEASE_API" || true

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -138,6 +138,17 @@ jobs:
             cd ../..
           fi
 
+      - name: List release assets (debug)
+        run: |
+          echo "Contents of release-assets:" 
+          ls -la release-assets || true
+          echo "Disk usage:" 
+          du -sh release-assets/* || true
+          if [ -z "$(ls -A release-assets 2>/dev/null)" ]; then
+            echo "No release assets found; aborting upload step"
+            exit 1
+          fi
+
       - name: Create draft release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -138,16 +138,10 @@ jobs:
             cd ../..
           fi
 
-      - name: List release assets (debug)
+      - name: Verify release assets exist
         run: |
           echo "Contents of release-assets:" 
-          ls -la release-assets || true
-          echo "Disk usage:" 
-          du -sh release-assets/* || true
-          if [ -z "$(ls -A release-assets 2>/dev/null)" ]; then
-            echo "No release assets found; aborting upload step"
-            exit 1
-          fi
+          ls -la release-assets
 
       - name: Create draft release
         id: create_release
@@ -164,46 +158,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload prebuild assets to draft release (verbose)
+      - name: Upload prebuild assets to draft release
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          echo "create_release outputs:"
-          echo "  upload_url: '${{ steps.create_release.outputs.upload_url }}'"
-          echo "  api url: '${{ steps.create_release.outputs.url }}'"
           UPLOAD_URL="${{ steps.create_release.outputs.upload_url }}"
           if [ -z "$UPLOAD_URL" ]; then
             echo "ERROR: No upload_url from create_release step"
             exit 1
           fi
-          # show files we will upload
-          echo "Files in release-assets:"
-          ls -la release-assets || true
-
+          CLEAN_URL="${UPLOAD_URL%\{*}"
           for f in release-assets/*; do
             [ -f "$f" ] || continue
             fname=$(basename "$f")
-            echo "---> Uploading $fname to $UPLOAD_URL"
-            # The upload_url returned by GitHub is a template like
-            # https://uploads.github.com/repos/.../assets{?name,label}
-            # Strip the template suffix before using it.
-            CLEAN_URL="${UPLOAD_URL%\{*}"
-            echo "Using upload endpoint: $CLEAN_URL?name=$fname"
-            resp_file="/tmp/upload_resp_${fname}"
-            # Use multipart/form-data as required by GitHub Releases API
-            http_status=$(curl -sS -o "$resp_file" -w "%{http_code}" -X POST \
+            echo "Uploading $fname"
+            curl -sS -X POST \
               -H "Authorization: token ${GITHUB_TOKEN}" \
               -F "file=@${f};type=application/zip" \
-              "${CLEAN_URL}?name=$fname") || true
-            echo "HTTP status: $http_status"
-            echo "Response body for $fname:" && cat "$resp_file" || true
-            echo "curl exit code: $?"
+              "${CLEAN_URL}?name=$fname"
           done
-
-          # After uploads, query the release to list attached assets
-          REPO_API="https://api.github.com/repos/${{ github.repository }}"
-          RELEASE_API="$REPO_API/releases/tags/v${{ steps.version.outputs.VERSION }}"
-          echo "Querying release API: $RELEASE_API"
-          curl -sS -H "Authorization: token ${GITHUB_TOKEN}" "$RELEASE_API" || true

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -146,10 +146,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload prebuild assets to release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: prebuild-${{ github.run_id }}
-          files: release-assets/*
+      - name: Upload prebuild assets to draft release
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          UPLOAD_URL="${{ steps.create_release.outputs.upload_url }}"
+          if [ -z "$UPLOAD_URL" ]; then
+            echo "No upload_url from create_release step"
+            exit 1
+          fi
+          for f in release-assets/*; do
+            [ -f "$f" ] || continue
+            fname=$(basename "$f")
+            echo "Uploading $fname to $UPLOAD_URL"
+            curl -sS -X POST \
+              -H "Authorization: token ${GITHUB_TOKEN}" \
+              -H "Content-Type: application/zip" \
+              --data-binary @"$f" "${UPLOAD_URL}?name=$fname"
+          done

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -149,6 +149,7 @@ jobs:
       - name: Upload prebuild assets to release
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: prebuild-${{ github.run_id }}
           files: release-assets/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Read package version
         id: version
         run: |
-          echo "VERSION=$(node -p \"require('./package.json').version\")" >> $GITHUB_OUTPUT
+          node -e "const fs=require('fs');const pkg=require('./package.json');const out=process.env.GITHUB_OUTPUT; if(!out){console.error('GITHUB_OUTPUT not set'); process.exit(1);} fs.appendFileSync(out, 'VERSION='+pkg.version + '\n');"
 
       - name: Download Linux prebuilds artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,83 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  npm-publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download prebuilds from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.release.tag_name }}"
+
+          echo "Downloading assets from release ${TAG}"
+          mkdir -p release-assets
+          gh release download "$TAG" --dir release-assets
+
+          echo "Downloaded assets:"
+          ls -la release-assets/
+
+          # Reconstruct the prebuilds/ directory structure.
+          # Assets are named <platform>-<arch>-<filename>.node
+          # (e.g., linux-x64-libraw.js.node, darwin-arm64-libraw.js.node)
+          # We need to place them at prebuilds/<platform>-<arch>/<filename>.node
+          mkdir -p prebuilds
+          for f in release-assets/*.node; do
+            [ -f "$f" ] || continue
+            fname=$(basename "$f")
+            # Extract platform-arch prefix (everything before the last dash-separated filename)
+            # e.g., "linux-x64-libraw.js.node" -> platform_arch="linux-x64", node_file="libraw.js.node"
+            # Split on the second dash: platform is first token, arch is second, rest is filename
+            platform=$(echo "$fname" | cut -d'-' -f1)
+            arch=$(echo "$fname" | cut -d'-' -f2)
+            node_file=$(echo "$fname" | cut -d'-' -f3-)
+            platform_arch="${platform}-${arch}"
+
+            mkdir -p "prebuilds/${platform_arch}"
+            echo "Placing ${fname} -> prebuilds/${platform_arch}/${node_file}"
+            cp "$f" "prebuilds/${platform_arch}/${node_file}"
+          done
+
+      - name: Verify prebuilds structure
+        run: |
+          echo "Prebuild contents:"
+          find prebuilds -type f -name "*.node"
+          # Expect:
+          # prebuilds/linux-x64/libraw.js.node
+          # prebuilds/darwin-arm64/libraw.js.node
+
+          # Fail if no prebuilds were found
+          count=$(find prebuilds -type f -name "*.node" | wc -l)
+          if [ "$count" -lt 1 ]; then
+            echo "ERROR: No .node prebuild files found"
+            exit 1
+          fi
+          echo "Found ${count} prebuild(s)"
+
+      - name: Install dependencies and build TypeScript
+        run: |
+          npm ci
+          npx tsc
+
+      - name: Dry-run publish (verify tarball contents)
+        run: npm pack --dry-run
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,5 +2,7 @@ build
 coverage
 dist
 node_modules
+prebuilds
+.claude
 .vscode/*
 docs/*

--- a/binding.gyp
+++ b/binding.gyp
@@ -24,11 +24,9 @@
           }
         }]
       ],
-      # Prefer explicit static libs in /usr/local for legacy setups, but also
-      # allow Homebrew locations and pkg-config discovered linker flags.
+      # Use linker flags and pkg-config to discover libs; avoid hardcoded
+      # absolute paths that may not exist on runners (e.g. /usr/local on macOS arm).
       "libraries": [
-        "/usr/local/lib/libraw_r.a",
-        "/usr/local/lib/libjpeg.a",
         "-L/opt/homebrew/lib",
         "-lraw_r",
         "-ljpeg",

--- a/binding.gyp
+++ b/binding.gyp
@@ -17,6 +17,13 @@
       ],
       "cflags!": ["-fno-exceptions"],
       "cflags_cc!": ["-fno-exceptions"],
+      # Require modern C++ standard for node-addon-api
+      "cflags_cc": ["-std=c++17"],
+      "xcode_settings": {
+        "CLANG_CXX_LANGUAGE_STANDARD": "c++17",
+        "CLANG_CXX_LIBRARY": "libc++",
+        "MACOSX_DEPLOYMENT_TARGET": "11.0"
+      },
       "conditions": [
         ['OS=="mac"', {
           'xcode_settings': {

--- a/binding.gyp
+++ b/binding.gyp
@@ -8,7 +8,12 @@
         "./src/wraptypes.cpp"
       ],
       "include_dirs": [
-        "<!@(node -p \"require('node-addon-api').include\")"
+  "<!@(node -p \"require('node-addon-api').include\")",
+  "/usr/local/include",
+  "/opt/homebrew/include",
+  # try to pick up any include flags pkg-config exposes for libraw/libjpeg
+  "<!@(pkg-config --cflags-only-I libraw 2>/dev/null | sed -E 's/-I//g' || true)",
+  "<!@(pkg-config --cflags-only-I libjpeg 2>/dev/null | sed -E 's/-I//g' || true)"
       ],
       "cflags!": ["-fno-exceptions"],
       "cflags_cc!": ["-fno-exceptions"],
@@ -19,7 +24,17 @@
           }
         }]
       ],
-      "libraries": ["/usr/local/lib/libraw_r.a", "/usr/local/lib/libjpeg.a"],
+      # Prefer explicit static libs in /usr/local for legacy setups, but also
+      # allow Homebrew locations and pkg-config discovered linker flags.
+      "libraries": [
+        "/usr/local/lib/libraw_r.a",
+        "/usr/local/lib/libjpeg.a",
+        "-L/opt/homebrew/lib",
+        "-lraw_r",
+        "-ljpeg",
+        "<!@(pkg-config --libs libraw 2>/dev/null || true)",
+        "<!@(pkg-config --libs libjpeg 2>/dev/null || true)"
+      ],
     }
   ]
 }

--- a/binding.gyp
+++ b/binding.gyp
@@ -8,16 +8,10 @@
         "./src/wraptypes.cpp"
       ],
       "include_dirs": [
-  "<!@(node -p \"require('node-addon-api').include\")",
-  "/usr/local/include",
-  "/opt/homebrew/include",
-  # try to pick up any include flags pkg-config exposes for libraw/libjpeg
-  "<!@(pkg-config --cflags-only-I libraw 2>/dev/null | sed -E 's/-I//g' || true)",
-  "<!@(pkg-config --cflags-only-I libjpeg 2>/dev/null | sed -E 's/-I//g' || true)"
+        "<!@(node -p \"require('node-addon-api').include\")"
       ],
       "cflags!": ["-fno-exceptions"],
       "cflags_cc!": ["-fno-exceptions"],
-      # Require modern C++ standard for node-addon-api
       "cflags_cc": ["-std=c++17"],
       "xcode_settings": {
         "CLANG_CXX_LANGUAGE_STANDARD": "c++17",
@@ -25,21 +19,53 @@
         "MACOSX_DEPLOYMENT_TARGET": "11.0"
       },
       "conditions": [
-        ['OS=="mac"', {
-          'xcode_settings': {
-            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
-          }
+        ["OS==\"mac\"", {
+          "xcode_settings": {
+            "GCC_ENABLE_CPP_EXCEPTIONS": "YES"
+          },
+          "include_dirs": [
+            "/usr/local/include",
+            "/opt/homebrew/include",
+            "<!@(pkg-config --cflags-only-I libraw 2>/dev/null | sed -E 's/-I//g' || true)",
+            "<!@(pkg-config --cflags-only-I libjpeg 2>/dev/null | sed -E 's/-I//g' || true)"
+          ],
+          "libraries": [
+            "-L/opt/homebrew/lib",
+            "-lraw_r",
+            "-ljpeg",
+            "<!@(pkg-config --libs libraw 2>/dev/null || true)",
+            "<!@(pkg-config --libs libjpeg 2>/dev/null || true)"
+          ]
+        }],
+        ["OS==\"linux\"", {
+          "include_dirs": [
+            "/usr/local/include",
+            "<!@(pkg-config --cflags-only-I libraw 2>/dev/null | sed -E 's/-I//g' || true)",
+            "<!@(pkg-config --cflags-only-I libjpeg 2>/dev/null | sed -E 's/-I//g' || true)"
+          ],
+          "libraries": [
+            "-lraw_r",
+            "-ljpeg",
+            "<!@(pkg-config --libs libraw 2>/dev/null || true)",
+            "<!@(pkg-config --libs libjpeg 2>/dev/null || true)"
+          ]
+        }],
+        ["OS==\"win\"", {
+          "msvs_settings": {
+            "VCCLCompilerTool": {
+              "ExceptionHandling": 1,
+              "AdditionalOptions": ["/std:c++17"]
+            }
+          },
+          "include_dirs": [
+            "<!@(node -e \"var p=process.env.LIBRAW_PREFIX||'';if(p)console.log(p+'/include')\")"
+          ],
+          "libraries": [
+            "<!@(node -e \"var p=process.env.LIBRAW_PREFIX||'';if(p)console.log(p+'/lib/raw.lib')\")",
+            "<!@(node -e \"var p=process.env.LIBRAW_PREFIX||'';if(p)console.log(p+'/lib/jpeg.lib')\")"
+          ]
         }]
-      ],
-      # Use linker flags and pkg-config to discover libs; avoid hardcoded
-      # absolute paths that may not exist on runners (e.g. /usr/local on macOS arm).
-      "libraries": [
-        "-L/opt/homebrew/lib",
-        "-lraw_r",
-        "-ljpeg",
-        "<!@(pkg-config --libs libraw 2>/dev/null || true)",
-        "<!@(pkg-config --libs libjpeg 2>/dev/null || true)"
-      ],
+      ]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,12 @@
   "types": "./dist/libraw.d.ts",
   "license": "LGPL-2.1",
   "gypfile": true,
+  "files": [
+    "dist/",
+    "prebuilds/",
+    "binding.gyp",
+    "src/"
+  ],
   "dependencies": {
     "node-addon-api": "^3.0.0",
     "node-gyp-build": "^4.6.0"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,12 @@
       "pre-push": "npm test"
     }
   },
+  "jest": {
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/.claude/"
+    ]
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/justinkambic/libraw.js.git"

--- a/test/libraw.test.ts
+++ b/test/libraw.test.ts
@@ -361,7 +361,7 @@ describe('LibRaw', () => {
 
   describe('version', () => {
     test('returns version string', async () => {
-      expect(await lr.version()).toEqual('0.21.1-Release');
+      expect(await lr.version()).toEqual('0.21.2-Release');
     });
   });
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                         
                                         
  - Add a complete CI pipeline for building, releasing, and publishing prebuilt native binaries for Linux (x64), macOS (arm64), and Windows (x64)                                                                    
  - Bundle prebuilds in the npm tarball so users don't need a compiler toolchain to install `libraw.js`                                                                                                              
  - Add a `publish.yml` workflow that reconstructs the prebuild directory from GitHub release assets and publishes to npm                                                                                            
                                                            
  ## Details                                                                                                                                                                                                         
                                                            
  **Prebuild workflow (`prebuild.yml`)**
  - Linux: builds LibRaw 0.21.2 and libjpeg from source
  - macOS: uses Homebrew for LibRaw and libjpeg                                                                                                                                                                      
  - Windows: uses vcpkg with `x64-windows-static-md` triplet for static linking compatible with Node.js's dynamic CRT
  - Creates a draft GitHub release with platform-prefixed `.node` assets                                                                                                                                             
                                                            
  **Publish workflow (`publish.yml`)**                                                                                                                                                                               
  - Triggers on release publish, downloads all prebuild assets, reconstructs `prebuilds/<platform>-<arch>/` structure, and runs `npm publish`
                                                                                                                                                                                                                     
  **Build system (`binding.gyp`)**
  - Restructured with per-OS conditions to avoid Unix shell commands (`pkg-config`, `sed`) on Windows                                                                                                                
  - Added Windows/MSVC condition with C++17, exception handling, and `LIBRAW_PREFIX` env var for vcpkg paths
  - C++17 and macOS deployment target (11.0) for node-addon-api compatibility                                                                                                                                        
   
  **Package (`package.json`)**                                                                                                                                                                                       
  - Added `files` field to explicitly whitelist `dist/`, `prebuilds/`, `binding.gyp`, and `src/` in the npm tarball
  - Version bumped to 3.0.0                                                                                                                                                                                          
   
  ## Test plan                                                                                                                                                                                                       
                                                            
  - [ ] Trigger `Build prebuilds` workflow via `workflow_dispatch` and verify all three platform jobs succeed
  - [ ] Verify draft release contains `linux-x64-`, `darwin-arm64-`, and `win32-x64-` prefixed `.node` assets
  - [ ] Publish the release and verify `Publish to npm` workflow succeeds                                                                                                                                            
  - [ ] `npm install libraw.js` on a clean machine loads the prebuild without compiling